### PR TITLE
Removed dspace-oai from the build process

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,7 @@
     state: restarted
 
 - name: rebuild DSpace
-  command: "mvn -Dskiptests package -P '!dspace-xmlui,!dspace-lni,!dspace-oai,!dspace-sword,!dspace-swordv2'"
+  command: "mvn -Dskiptests package -P '!dspace-xmlui,!dspace-lni,!dspace-sword,!dspace-swordv2'"
   args:
     chdir: "{{ dspace_src_dir }}"
   become_user: "{{ dspace_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,7 @@
   tags: build
 
 - name: build DSpace
-  command: "mvn -q -Dskiptests package -P '!dspace-xmlui,!dspace-lni,!dspace-oai,!dspace-sword,!dspace-swordv2'"
+  command: "mvn -q -Dskiptests package -P '!dspace-xmlui,!dspace-lni,!dspace-sword,!dspace-swordv2'"
   args:
     chdir: "{{ dspace_src_dir }}"
   become_user: "{{ dspace_user }}"


### PR DESCRIPTION
Required for the standard build commands to work. Something about dependencies, John told me about this.